### PR TITLE
Add Ice cookbook section and link to cookbook project in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Using basic setup, you don't need any extra code change and you will use the pro
 
 ##Ice Cookbook: 
 
-1. A community cookbook is available to for deploying Ice via Chef here https://github.com/mdsol/ice_cookbook.
+1. A community cookbook is available for deploying Ice via Chef here https://github.com/mdsol/ice_cookbook.
 
   
 ##Advanced options:


### PR DESCRIPTION
I put together an Ice cookbook which will deploy Ice via a war on Tomcat.  The cookbook uses nginx as a reverse proxy to tomcat and uses the riot games artifact cookbook to handle deployments.
