### PR TITLE
cc2 type present under cc1 in reservation json files

### DIFF
--- a/src/java/com/netflix/ice/basic/BasicReservationService.java
+++ b/src/java/com/netflix/ice/basic/BasicReservationService.java
@@ -64,6 +64,7 @@ public class BasicReservationService extends Poller implements ReservationServic
         instanceTypes.put("hiMemResI", "m2");
         instanceTypes.put("hiCPUResI", "c1");
         instanceTypes.put("clusterCompResI", "cc1");
+        instanceTypes.put("clusterCompResI", "cc2");
         instanceTypes.put("clusterHiMemResI", "cr1");
         instanceTypes.put("clusterGPUResI", "cg1");
         instanceTypes.put("hiIoResI", "hi1");


### PR DESCRIPTION
The cc2 type (more specifically, cc2.8xlarge) is present in the reservation pricing JSON files as cc1.xxxxxxxxl.  I've had a UsageType of 'BoxUsage:cc2.8xlarge' cause NullPointerExceptions when trying to determine the pricing for this instance type.
