### PR TITLE
Install script updates

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,8 @@ GRAILS_VERSION=2.2.1
 # Install prerequisites
 sudo yum -y install git java-1.6.0-openjdk-devel.x86_64 wget
 
+INSTALL_DIR=$(pwd)
+
 cd
 
 HOME_DIR=$(pwd)
@@ -27,15 +29,16 @@ GRAILS_HOME=${HOME_DIR}/.grails/wrapper/${GRAILS_VERSION}/grails-${GRAILS_VERSIO
 PATH=$PATH:${HOME_DIR}/.grails/wrapper/${GRAILS_VERSION}/grails-${GRAILS_VERSION}/bin/
 
 # Get ice
-cd
-if [ -x 'ice/.git' ]; then
+cd ${INSTALL_DIR}
+
+if [ -x '.git' ]; then
   # We already have it; update to latest git
-  cd ice
   git pull
 else
   # We don't have it at all yet; clone the repo
   git clone https://github.com/Netflix/ice.git
   cd ice
+  INSTALL_DIR=$(pwd)
 fi
 
 # Initialize Ice with Grails


### PR DESCRIPTION
Some bug fixes and updates to the `install.sh` script:
- Ensure `wget` is available.
- Don't assume home directory is that of `ec2-user`.
- Make sure `GRAILS_HOME` and `PATH` are set properly even if grails was already there and not downloaded by the script.
- Pass `JAVA_OPTS` to `grails` so we can use a proxy.
- Don't clone ice into the home directory if we're not running the script in there.
