### PR TITLE
Add unzip as a dependency

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,7 @@
 GRAILS_VERSION=2.2.1
 
 # Install prerequisites
-sudo yum -y install git java-1.6.0-openjdk-devel.x86_64 wget
+sudo yum -y install git java-1.6.0-openjdk-devel.x86_64 wget unzip
 
 INSTALL_DIR=$(pwd)
 


### PR DESCRIPTION
unzip should be added as a dependency, as it is not installed per default on a minimal installation.
