### PR TITLE
Bump httpcomponents versions to match AWS version bump

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -75,8 +75,8 @@ grails.project.dependency.resolution = {
                 // Transitive dependencies of aws-java-sdk, but also used directly.
                 // It would be great if we could upgrade httpcore and httpclient, but we can't until the AWS Java SDK
                 // upgrades its dependencies. If we simply upgrade these, then some Amazon calls fail.
-                'org.apache.httpcomponents:httpcore:4.1',
-                'org.apache.httpcomponents:httpclient:4.1.1',
+                'org.apache.httpcomponents:httpcore:4.2',
+                'org.apache.httpcomponents:httpclient:4.2',
 
                 // Explicitly including aws-java-sdk transitive dependencies
                 'org.codehaus.jackson:jackson-core-asl:1.8.9',


### PR DESCRIPTION
aws-java-sdk 1.5.8 requires httpcomponents version 4.2. If you use version 4.1.1 you will get an exception about a missing class name.
