### PR TITLE
Removed quotes from around ice.highstockUrl value.

### DIFF
--- a/src/java/sample.properties
+++ b/src/java/sample.properties
@@ -14,7 +14,7 @@ ice.reservationPeriod=threeyear
 ice.reservationUtilization=HEAVY
 
 # the highstock url; host it somewhere else and change this if you need HTTPS
-ice.highstockUrl="http://code.highcharts.com/stock/highstock.js"
+ice.highstockUrl=http://code.highcharts.com/stock/highstock.js
 
 # url prefix, e.g. http://ice.netflix.com/. Will be used in alert emails.
 ice.urlPrefix=


### PR DESCRIPTION
The quotes around the highchart.js url get doubled up, and kept another correctly edited sample.properties file from working until they were removed. 
