### PR TITLE
Update the link to the AWS Account Billing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ When representing the cost profile for individual resources, Ice will factor the
 
 ##Prerequisite:
 
-1. First sign up for Amazon's programmatic billing access [here](http://docs.aws.amazon.com/awsaccountbilling/latest/about/programaccess.html) to receive detailed billing(hourly) reports. Verify you receive monthly billing file in the following format: `<accountid>-aws-billing-detailed-line-items-<year>-<month>.csv.zip`.
+1. First sign up for Amazon's programmatic billing access [here](http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/BillOptionsReportConfig.html) to receive detailed billing(hourly) reports. Verify you receive monthly billing file in the following format: `<accountid>-aws-billing-detailed-line-items-<year>-<month>.csv.zip`.
 2. Install Grails 2.2.1 and set GRAILS_HOME and JAVA_HOME
 3. Ice uses [highstock](http://www.highcharts.com/) to generate interactive graphs. Please make sure you acquire the proper license before using it.
   


### PR DESCRIPTION
A trivial README fix.  The old link goes to a page that says it has been superseded.
