### PR TITLE
Zip64 Support via Commons Compress.

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -87,6 +87,9 @@ grails.project.dependency.resolution = {
 
                 // Easier Java from of the Apache Foundation
                 'commons-lang:commons-lang:2.4',
+     
+                // Better Zip Support
+                'org.apache.commons:commons-compress:1.8',
 
                 // Easier Java from Joshua Bloch and Google
                 'com.google.guava:guava:14.0',

--- a/src/java/com/netflix/ice/processor/BillingFileProcessor.java
+++ b/src/java/com/netflix/ice/processor/BillingFileProcessor.java
@@ -33,6 +33,8 @@ import com.netflix.ice.tag.Product;
 import com.netflix.ice.tag.Zone;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
+import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Months;
@@ -41,8 +43,6 @@ import org.joda.time.Weeks;
 import java.io.*;
 import java.text.NumberFormat;
 import java.util.*;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
 /**
  * Class to process billing files and produce tag, usage, cost output files for reader/UI.
@@ -526,12 +526,10 @@ public class BillingFileProcessor extends Poller {
     private void processBillingZipFile(File file, boolean withTags) throws IOException {
 
         InputStream input = new FileInputStream(file);
-        ZipInputStream zipInput;
-
-        zipInput = new ZipInputStream(input);
+        ZipArchiveInputStream zipInput = new ZipArchiveInputStream(input);
 
         try {
-            ZipEntry entry;
+            ArchiveEntry entry;
             while ((entry = zipInput.getNextEntry()) != null) {
                 if (entry.isDirectory())
                     continue;


### PR DESCRIPTION
Hello,
    Ran into issues with reading large Zip files.  I saw you guys already depended on some Apache commons libs and Commons Compress is a drop-in replacement.  Here is the exception that is addressed:

java.util.zip.ZipException: invalid entry size (expected 5629585467198288 but got 8312381342 bytes)
        at java.util.zip.ZipInputStream.readEnd(ZipInputStream.java:403)
        at java.util.zip.ZipInputStream.read(ZipInputStream.java:195)
        at java.io.InputStreamReader.read(InputStreamReader.java:184)
        at com.netflix.ice.processor.BillingFileProcessor.processBillingFile(BillingFileProcessor.java:575)
        at com.netflix.ice.processor.BillingFileProcessor.processBillingZipFile(BillingFileProcessor.java:539)
        at com.netflix.ice.processor.BillingFileProcessor.poll(BillingFileProcessor.java:187)
        at com.netflix.ice.common.Poller.doWork(Poller.java:50)
        at com.netflix.ice.common.Poller.access$000(Poller.java:28)
        at com.netflix.ice.common.Poller$1.run(Poller.java:88)
        at java.lang.Thread.run(Thread.java:744)

Thanks,

Anthony
