### PR TITLE
Tomcat version and groovy version shouldn't be the same

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -120,6 +120,6 @@ grails.project.dependency.resolution = {
     }
 
     plugins {
-        build ":tomcat:$grailsVersion"
+        build ":tomcat:2.2.1"
     }
 }

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -120,6 +120,6 @@ grails.project.dependency.resolution = {
     }
 
     plugins {
-        build ":tomcat:2.2.1"
+        build ":tomcat:8.0.15"
     }
 }


### PR DESCRIPTION
Ice ships with 2.2.1 by default.  I suspect this file was refactored to replace "2.2.1" with groovyVersion, but they're not necessarily the same.