### PR TITLE
add support for unblended billing values

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,11 @@ Options with * require writing your own code.
    
   You may also want to show your organization's throughput metric alongside usage and cost. You can choose to implement interface ThroughputMetricService, or you can simply use the existing BasicThroughputMetricService. Using BasicThroughputMetricService requires the throughput metric data to be stores monthly in files with names like <filePrefix>_2013_04, <filePrefix>_2013_05. Data in files should be delimited by new lines. <filePrefix> is specified when you create BasicThroughputMetricService instance.
 
+9. UnBlended Costs
+  By default, blended costs are shown. You can show Unblended costs with the following configuration:
+
+        ice.use_blended=false
+
 ##Support
 
 Please use the [Ice Google Group](https://groups.google.com/d/forum/iceusers) for general questions and discussion.

--- a/README.md
+++ b/README.md
@@ -240,10 +240,10 @@ Options with * require writing your own code.
    
   You may also want to show your organization's throughput metric alongside usage and cost. You can choose to implement interface ThroughputMetricService, or you can simply use the existing BasicThroughputMetricService. Using BasicThroughputMetricService requires the throughput metric data to be stores monthly in files with names like <filePrefix>_2013_04, <filePrefix>_2013_05. Data in files should be delimited by new lines. <filePrefix> is specified when you create BasicThroughputMetricService instance.
 
-9. UnBlended Costs
-  By default, blended costs are shown. You can show Unblended costs with the following configuration:
+9. Blended Costs
+  By default, unblended costs are shown. You can show Blended costs with the following configuration:
 
-        ice.use_blended=false
+        ice.use_blended=true
 
 ##Support
 

--- a/src/java/com/netflix/ice/basic/BasicLineItemProcessor.java
+++ b/src/java/com/netflix/ice/basic/BasicLineItemProcessor.java
@@ -50,7 +50,7 @@ public class BasicLineItemProcessor implements LineItemProcessor {
 
     private List<String> header;
 
-    public void initIndexes(boolean withTags, String[] header) {
+    public void initIndexes(ProcessorConfig processorConfig, boolean withTags, String[] header) {
         boolean hasBlendedCost = false;
         for (String column: header) {
             if (column.equalsIgnoreCase("UnBlendedCost")) {
@@ -70,6 +70,8 @@ public class BasicLineItemProcessor implements LineItemProcessor {
         endTimeIndex = 15 + (withTags ? 0 : -1);
         rateIndex = 19 + (withTags ? 0 : -1) + (hasBlendedCost ? 0 : -2);
         costIndex = 20 + (withTags ? 0 : -1) + (hasBlendedCost ? 0 : -2);
+        rateIndex = 19 + (withTags ? 0 : -1) + ((hasBlendedCost && useBlendedCost) ? 0 : -2);
+        costIndex = 20 + (withTags ? 0 : -1) + ((hasBlendedCost && useBlendedCost) ? 0 : -2);
         resourceIndex = 21 + (withTags ? 0 : -1) + (hasBlendedCost ? 0 : -2);
 
         this.header = Lists.newArrayList(header);

--- a/src/java/com/netflix/ice/basic/BasicLineItemProcessor.java
+++ b/src/java/com/netflix/ice/basic/BasicLineItemProcessor.java
@@ -69,10 +69,13 @@ public class BasicLineItemProcessor implements LineItemProcessor {
         usageQuantityIndex = 16 + (withTags ? 0 : -1);
         startTimeIndex = 14 + (withTags ? 0 : -1);
         endTimeIndex = 15 + (withTags ? 0 : -1);
-        rateIndex = 19 + (withTags ? 0 : -1) + (hasBlendedCost ? 0 : -2);
-        costIndex = 20 + (withTags ? 0 : -1) + (hasBlendedCost ? 0 : -2);
-        rateIndex = 19 + (withTags ? 0 : -1) + ((hasBlendedCost && useBlendedCost) ? 0 : -2);
-        costIndex = 20 + (withTags ? 0 : -1) + ((hasBlendedCost && useBlendedCost) ? 0 : -2);
+        // When blended vales are present, the rows look like this
+        //    ..., UsageQuantity, BlendedRate, BlendedCost, UnBlended Rate, UnBlended Cost
+        // Without Blended Rates
+        //    ..., UsageQuantity, UnBlendedRate, UnBlendedCost
+        // We want to always reference the UnBlended Cost unless useBlendedCost is true.
+        rateIndex = 19 + (withTags ? 0 : -1) + ((hasBlendedCost && useBlendedCost == false) ? 0 : -2);
+        costIndex = 20 + (withTags ? 0 : -1) + ((hasBlendedCost && useBlendedCost == false) ? 0 : -2);
         resourceIndex = 21 + (withTags ? 0 : -1) + (hasBlendedCost ? 0 : -2);
 
         this.header = Lists.newArrayList(header);

--- a/src/java/com/netflix/ice/basic/BasicLineItemProcessor.java
+++ b/src/java/com/netflix/ice/basic/BasicLineItemProcessor.java
@@ -52,6 +52,7 @@ public class BasicLineItemProcessor implements LineItemProcessor {
 
     public void initIndexes(ProcessorConfig processorConfig, boolean withTags, String[] header) {
         boolean hasBlendedCost = false;
+        boolean useBlendedCost = processorConfig.useBlended;
         for (String column: header) {
             if (column.equalsIgnoreCase("UnBlendedCost")) {
                 hasBlendedCost = true;

--- a/src/java/com/netflix/ice/common/IceOptions.java
+++ b/src/java/com/netflix/ice/common/IceOptions.java
@@ -81,6 +81,11 @@ public class IceOptions {
     public static final String CUSTOM_TAGS = "ice.customTags";
 
     /**
+     * Boolean Flag whether to use blended or Unblended Costs.  Default is Blended Cost(true)
+     */
+    public static final String USE_BLENDED = "ice.use_blended";
+
+    /**
      * s3 bucket name where output files are to be store. Both read and write permissions are needed. It must be specified in Config.
      */
     public static final String WORK_S3_BUCKET_NAME = "ice.work_s3bucketname";

--- a/src/java/com/netflix/ice/common/IceOptions.java
+++ b/src/java/com/netflix/ice/common/IceOptions.java
@@ -81,7 +81,7 @@ public class IceOptions {
     public static final String CUSTOM_TAGS = "ice.customTags";
 
     /**
-     * Boolean Flag whether to use blended or Unblended Costs.  Default is Blended Cost(true)
+     * Boolean Flag whether to use blended or Unblended Costs.  Default is UnBlended Cost(false)
      */
     public static final String USE_BLENDED = "ice.use_blended";
 

--- a/src/java/com/netflix/ice/processor/BillingFileProcessor.java
+++ b/src/java/com/netflix/ice/processor/BillingFileProcessor.java
@@ -568,7 +568,7 @@ public class BillingFileProcessor extends Poller {
             reader.readRecord();
             String[] headers = reader.getValues();
 
-            config.lineItemProcessor.initIndexes(withTags, headers);
+            config.lineItemProcessor.initIndexes(config, withTags, headers);
 
             while (reader.readRecord()) {
                 String[] items = reader.getValues();

--- a/src/java/com/netflix/ice/processor/LineItemProcessor.java
+++ b/src/java/com/netflix/ice/processor/LineItemProcessor.java
@@ -32,7 +32,7 @@ public interface LineItemProcessor {
     public static final DateTimeFormatter amazonBillingDateFormat = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss").withZone(DateTimeZone.UTC);
     public static final DateTimeFormatter amazonBillingDateFormat2 = DateTimeFormat.forPattern("yyyy/MM/dd HH:mm:ss").withZone(DateTimeZone.UTC);
 
-    void initIndexes(boolean withTags, String[] header);
+    void initIndexes(ProcessorConfig config, boolean withTags, String[] header);
     List<String> getHeader();
     int getUserTagStartIndex();
     long getEndMillis(String[] items);

--- a/src/java/com/netflix/ice/processor/ProcessorConfig.java
+++ b/src/java/com/netflix/ice/processor/ProcessorConfig.java
@@ -41,6 +41,7 @@ public class ProcessorConfig extends Config {
     public final LineItemProcessor lineItemProcessor;
     public final Randomizer randomizer;
     public final double costPerMonitorMetricPerHour;
+    public final boolean useBlended;
 
     public final String useCostForResourceGroup;
 
@@ -85,6 +86,7 @@ public class ProcessorConfig extends Config {
         billingAccessExternalIds = properties.getProperty(IceOptions.BILLING_ACCESS_EXTERNALID, "").split(",");
 
         customTags = properties.getProperty(IceOptions.CUSTOM_TAGS, "").split(",");
+        useBlended = properties.getProperty(IceOptions.USE_BLENDED) == null ? true : Boolean.parseBoolean(properties.getProperty(IceOptions.USE_BLENDED));
 
         useCostForResourceGroup = properties.getProperty(IceOptions.RESOURCE_GROUP_COST, "modeled");
 

--- a/src/java/com/netflix/ice/processor/ProcessorConfig.java
+++ b/src/java/com/netflix/ice/processor/ProcessorConfig.java
@@ -86,7 +86,7 @@ public class ProcessorConfig extends Config {
         billingAccessExternalIds = properties.getProperty(IceOptions.BILLING_ACCESS_EXTERNALID, "").split(",");
 
         customTags = properties.getProperty(IceOptions.CUSTOM_TAGS, "").split(",");
-        useBlended = properties.getProperty(IceOptions.USE_BLENDED) == null ? true : Boolean.parseBoolean(properties.getProperty(IceOptions.USE_BLENDED));
+        useBlended = properties.getProperty(IceOptions.USE_BLENDED) == null ? false : Boolean.parseBoolean(properties.getProperty(IceOptions.USE_BLENDED));
 
         useCostForResourceGroup = properties.getProperty(IceOptions.RESOURCE_GROUP_COST, "modeled");
 


### PR DESCRIPTION
Add Support to show unblended billing values.  By default, blended values are still shown, but some people may be interested in using the unblended values instead.