### PR TITLE
Disable SHA1 checks on dependencies fetching.

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -26,6 +26,7 @@ grails.project.dependency.resolution = {
     // inherit Grails' default dependencies
     inherits("global") {
     }
+    checksums false // Disable checksum check. If it's enabled the dependency fetching fails
     log "warn" // log level of Ivy resolver, either 'error', 'warn', 'info', 'debug' or 'verbose'
     repositories {
         grailsPlugins()


### PR DESCRIPTION
install.sh fails to fetch dependencies when SHA1 verification fails.
This change disables the checksum check.