### PR TITLE
Fix npe on bootstrap for new sa-east-1 zone 'c'

### DIFF
--- a/src/java/com/netflix/ice/basic/BasicLineItemProcessor.java
+++ b/src/java/com/netflix/ice/basic/BasicLineItemProcessor.java
@@ -122,6 +122,10 @@ public class BasicLineItemProcessor implements LineItemProcessor {
         UsageType usageType = reformedMetaData.usageType;
         Zone zone = Zone.getZone(items[zoneIndex], reformedMetaData.region);
 
+        // TWC: @Ckelner - Hack to get zone where region has shortname and zone is empty in csv line item
+        if(!(checkForRegionShortName(items[usageTypeIndex]).isEmpty()))
+            zone = getEmptyZoneFromRegion(reformedMetaData.region, zone);
+
         int startIndex = (int)((millisStart - startMilli)/ AwsUtils.hourMillis);
         int endIndex = (int)((millisEnd + 1000 - startMilli)/ AwsUtils.hourMillis);
 
@@ -353,7 +357,7 @@ public class BasicLineItemProcessor implements LineItemProcessor {
 
         // first try to retrieve region info
         int index = usageTypeStr.indexOf("-");
-        String regionShortName = index > 0 ? usageTypeStr.substring(0, index) : "";
+        String regionShortName = checkForRegionShortName(usageTypeStr);
         Region region = regionShortName.isEmpty() ? null : Region.getRegionByShortName(regionShortName);
         if (region != null) {
             usageTypeStr = usageTypeStr.substring(index+1);
@@ -433,6 +437,26 @@ public class BasicLineItemProcessor implements LineItemProcessor {
         }
 
         return new ReformedMetaData(region, product, operation, usageType);
+    }
+
+    private String checkForRegionShortName(String usageTypeStr) {
+        int index = usageTypeStr.indexOf("-");
+        return index > 0 ? usageTypeStr.substring(0, index) : "";
+    }
+
+    /*
+    There are line items in the AWS csv which have a short region name in the UsageType field
+    but which have no zone entry.  See example:
+    InvoiceID,  PayerAccountId,LinkedAccountId,RecordType,RecordId,            ProductName,                   RateId,  SubscriptionId,PricingPlanId,UsageType,               Operation,     AvailabilityZone,ReservedInstance,ItemDescription,...
+    "Estimated","123456789",   "987654321",    "LineItem","400000000223405011","Amazon Elastic Compute Cloud","3207476",              ,            ,"EU-HeavyUsage:r3.large","RunInstances",,                "Y",             "USD 0.0323 hourly fee per Linux/UNIX (Amazon VPC), r3.large instance (1488.0 hours purchased, 1488.0 hours used)",...
+    So where this occurs, we default to the "a" zone of a given region.
+     */
+    private Zone getEmptyZoneFromRegion(Region region, Zone zone) {
+        if(zone == null) {
+            logger.info("Zone not found, will default to zone 'a' for region: " + region.name);
+            return Zone.getZone(region.name + "a", region);
+        }
+        return zone;
     }
 
     private InstanceOs getInstanceOs(String operationStr) {

--- a/src/java/com/netflix/ice/basic/BasicLineItemProcessor.java
+++ b/src/java/com/netflix/ice/basic/BasicLineItemProcessor.java
@@ -123,8 +123,9 @@ public class BasicLineItemProcessor implements LineItemProcessor {
         Zone zone = Zone.getZone(items[zoneIndex], reformedMetaData.region);
 
         // TWC: @Ckelner - Hack to get zone where region has shortname and zone is empty in csv line item
-        if(!(checkForRegionShortName(items[usageTypeIndex]).isEmpty()))
+        if(!(checkForRegionShortName(items[usageTypeIndex]).isEmpty())) {
             zone = getEmptyZoneFromRegion(reformedMetaData.region, zone);
+        }
 
         int startIndex = (int)((millisStart - startMilli)/ AwsUtils.hourMillis);
         int endIndex = (int)((millisEnd + 1000 - startMilli)/ AwsUtils.hourMillis);

--- a/src/java/com/netflix/ice/basic/BasicReservationService.java
+++ b/src/java/com/netflix/ice/basic/BasicReservationService.java
@@ -171,10 +171,15 @@ public class BasicReservationService extends Poller implements ReservationServic
                         }
                     }
                     UsageType usageType = getUsageType(offer.getInstanceType(), offer.getProductDescription());
-                    hasNewPrice = setPrice(utilization, currentTime, Zone.getZone(offer.getAvailabilityZone()).region, usageType,
-                            offer.getFixedPrice(), hourly) || hasNewPrice;
+                    Zone zone = Zone.getZone(offer.getAvailabilityZone());
+                    if( zone != null ) {
+                        hasNewPrice = setPrice(utilization, currentTime, zone.region, usageType, offer.getFixedPrice(), hourly)||
+                            hasNewPrice;
 
-                    logger.info("Setting RI price for " + Zone.getZone(offer.getAvailabilityZone()).region + " " + utilization + " " + usageType + " " + offer.getFixedPrice() + " " + hourly);
+                        logger.info("Setting RI price for " + zone.region + " " + utilization + " " + usageType + " " + offer.getFixedPrice() + " " + hourly);
+                    } else {
+                        logger.warn("Not able to setting RI price for: zone=" + offer.getAvailabilityZone() + " - utilization=" + utilization + " - usageType=" + usageType + " - fixedPrice=" + offer.getFixedPrice() + " - hourly=" + hourly);
+                    }
                 }
             } while (!StringUtils.isEmpty(token));
         }

--- a/src/java/com/netflix/ice/basic/BasicReservationService.java
+++ b/src/java/com/netflix/ice/basic/BasicReservationService.java
@@ -178,7 +178,7 @@ public class BasicReservationService extends Poller implements ReservationServic
 
                         logger.info("Setting RI price for " + zone.region + " " + utilization + " " + usageType + " " + offer.getFixedPrice() + " " + hourly);
                     } else {
-                        logger.warn("Not able to setting RI price for: zone=" + offer.getAvailabilityZone() + " - utilization=" + utilization + " - usageType=" + usageType + " - fixedPrice=" + offer.getFixedPrice() + " - hourly=" + hourly);
+                        logger.warn("Not able to set RI price for: zone=" + offer.getAvailabilityZone() + " - utilization=" + utilization + " - usageType=" + usageType + " - fixedPrice=" + offer.getFixedPrice() + " - hourly=" + hourly);
                     }
                 }
             } while (!StringUtils.isEmpty(token));

--- a/src/java/com/netflix/ice/tag/Zone.java
+++ b/src/java/com/netflix/ice/tag/Zone.java
@@ -57,6 +57,7 @@ public class Zone extends Tag {
 
     public static final Zone SA_EAST_1A = new Zone(Region.SA_EAST_1, "sa-east-1a");
     public static final Zone SA_EAST_1B = new Zone(Region.SA_EAST_1, "sa-east-1b");
+    public static final Zone SA_EAST_1C = new Zone(Region.SA_EAST_1, "sa-east-1c");
 
     public static final Zone AP_NORTHEAST_1A = new Zone(Region.AP_NORTHEAST_1, "ap-northeast-1a");
     public static final Zone AP_NORTHEAST_1B = new Zone(Region.AP_NORTHEAST_1, "ap-northeast-1b");
@@ -94,6 +95,7 @@ public class Zone extends Tag {
 
         zonesByName.put(SA_EAST_1A.name, SA_EAST_1A);
         zonesByName.put(SA_EAST_1B.name, SA_EAST_1B);
+        zonesByName.put(SA_EAST_1C.name, SA_EAST_1C);
 
         zonesByName.put(AP_NORTHEAST_1A.name, AP_NORTHEAST_1A);
         zonesByName.put(AP_NORTHEAST_1B.name, AP_NORTHEAST_1B);

--- a/src/java/com/netflix/ice/tag/Zone.java
+++ b/src/java/com/netflix/ice/tag/Zone.java
@@ -114,8 +114,14 @@ public class Zone extends Tag {
     }
 
     public static Zone getZone(String name, Region region) {
-        if (name.isEmpty() || name.equals(region.name))
-            return null;
+        if (name.isEmpty() || name.equals(region.name)) {
+          // zone is empty for us-east-1a entries
+          if ( region == Region.US_EAST_1 ) {
+              name = US_EAST_1A.name;
+          } else {
+              return null;
+          }
+        }
         Zone zone = zonesByName.get(name);
         if (zone == null) {
             zonesByName.putIfAbsent(name, new Zone(region, name));


### PR DESCRIPTION
Closes TheWeatherCompany/ice#9

NullPointerException in BasicReservationService during BootStrap:
```log
2015-02-25 20:24:47,004 [localhost-startStop-1] ERROR basic.BasicReservationService  - failed to poll reservation prices
java.lang.NullPointerException
	at com.netflix.ice.basic.BasicReservationService.pollAPI(BasicReservationService.java:174)
	at com.netflix.ice.basic.BasicReservationService.init(BasicReservationService.java:106)
	at com.netflix.ice.processor.ProcessorConfig.<init>(ProcessorConfig.java:93)
	at BootStrap$_closure1.doCall(BootStrap.groovy:186)
	at grails.util.Environment.evaluateEnvironmentSpecificBlock(Environment.java:308)
	at grails.util.Environment.executeForEnvironment(Environment.java:301)
	at grails.util.Environment.executeForCurrentEnvironment(Environment.java:277)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
java.lang.RuntimeException: failed to poll reservation prices for null
```

After some investigation, appears be stemming from this line: https://github.com/Netflix/ice/blob/master/src/java/com/netflix/ice/basic/BasicReservationService.java#L174
```java
 hasNewPrice = setPrice(utilization, currentTime, Zone.getZone(offer.getAvailabilityZone()).region, usageType, offer.getFixedPrice(), hourly) || hasNewPrice;
```
Specifically it is `Zone.getZone(offer.getAvailabilityZone()).region`
Where `Zone.getZone()` can return null as seen here: https://github.com/netflix/ice/blob/master/src/java/com/netflix/ice/tag/Zone.java#L118
```java
if (name.isEmpty() || name.equals(region.name))
            return null;
```

And after adding some logging I found there was a new zone for `sa-east-1`:
```log
2015-02-26 13:23:13,591 [localhost-startStop-1] WARN  basic.BasicReservationService  - Not able to setting RI price for: zone=sa-east-1c - utilization=HEAVY - usageType=m3.xlarge.sqlserverweb - fixedPrice=10550.0 - hourly=0.0
2015-02-26 13:23:13,591 [localhost-startStop-1] WARN  basic.BasicReservationService  - Not able to setting RI price for: zone=sa-east-1c - utilization=HEAVY - usageType=m3.xlarge.sqlserverstd - fixedPrice=19683.0 - hourly=0.0
```