### PR TITLE
Fix NullPointerException in BasicReservationService during BootStrap

### DIFF
--- a/src/java/com/netflix/ice/basic/BasicReservationService.java
+++ b/src/java/com/netflix/ice/basic/BasicReservationService.java
@@ -171,10 +171,15 @@ public class BasicReservationService extends Poller implements ReservationServic
                         }
                     }
                     UsageType usageType = getUsageType(offer.getInstanceType(), offer.getProductDescription());
-                    hasNewPrice = setPrice(utilization, currentTime, Zone.getZone(offer.getAvailabilityZone()).region, usageType,
-                            offer.getFixedPrice(), hourly) || hasNewPrice;
+                    Zone zone = Zone.getZone(offer.getAvailabilityZone());
+                    if( zone != null ) {
+                        hasNewPrice = setPrice(utilization, currentTime, zone.region, usageType, offer.getFixedPrice(), hourly)||
+                            hasNewPrice;
 
-                    logger.info("Setting RI price for " + Zone.getZone(offer.getAvailabilityZone()).region + " " + utilization + " " + usageType + " " + offer.getFixedPrice() + " " + hourly);
+                        logger.info("Setting RI price for " + zone.region + " " + utilization + " " + usageType + " " + offer.getFixedPrice() + " " + hourly);
+                    } else {
+                        logger.warn("Not able to setting RI price for: zone=" + offer.getAvailabilityZone() + " - utilization=" + utilization + " - usageType=" + usageType + " - fixedPrice=" + offer.getFixedPrice() + " - hourly=" + hourly);
+                    }
                 }
             } while (!StringUtils.isEmpty(token));
         }

--- a/src/java/com/netflix/ice/tag/Zone.java
+++ b/src/java/com/netflix/ice/tag/Zone.java
@@ -57,6 +57,7 @@ public class Zone extends Tag {
 
     public static final Zone SA_EAST_1A = new Zone(Region.SA_EAST_1, "sa-east-1a");
     public static final Zone SA_EAST_1B = new Zone(Region.SA_EAST_1, "sa-east-1b");
+    public static final Zone SA_EAST_1C = new Zone(Region.SA_EAST_1, "sa-east-1c");
 
     public static final Zone AP_NORTHEAST_1A = new Zone(Region.AP_NORTHEAST_1, "ap-northeast-1a");
     public static final Zone AP_NORTHEAST_1B = new Zone(Region.AP_NORTHEAST_1, "ap-northeast-1b");
@@ -94,6 +95,7 @@ public class Zone extends Tag {
 
         zonesByName.put(SA_EAST_1A.name, SA_EAST_1A);
         zonesByName.put(SA_EAST_1B.name, SA_EAST_1B);
+        zonesByName.put(SA_EAST_1C.name, SA_EAST_1C);
 
         zonesByName.put(AP_NORTHEAST_1A.name, AP_NORTHEAST_1A);
         zonesByName.put(AP_NORTHEAST_1B.name, AP_NORTHEAST_1B);


### PR DESCRIPTION
Closes TheWeatherCompany/ice#9

NullPointerException in BasicReservationService during BootStrap:
```log
2015-02-25 20:24:47,004 [localhost-startStop-1] ERROR basic.BasicReservationService  - failed to poll reservation prices
java.lang.NullPointerException
	at com.netflix.ice.basic.BasicReservationService.pollAPI(BasicReservationService.java:174)
	at com.netflix.ice.basic.BasicReservationService.init(BasicReservationService.java:106)
	at com.netflix.ice.processor.ProcessorConfig.<init>(ProcessorConfig.java:93)
	at BootStrap$_closure1.doCall(BootStrap.groovy:186)
	at grails.util.Environment.evaluateEnvironmentSpecificBlock(Environment.java:308)
	at grails.util.Environment.executeForEnvironment(Environment.java:301)
	at grails.util.Environment.executeForCurrentEnvironment(Environment.java:277)
	at java.util.concurrent.FutureTask.run(FutureTask.java:262)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
java.lang.RuntimeException: failed to poll reservation prices for null
```

After some investigation, appears be stemming from this line: https://github.com/Netflix/ice/blob/master/src/java/com/netflix/ice/basic/BasicReservationService.java#L174
```java
 hasNewPrice = setPrice(utilization, currentTime, Zone.getZone(offer.getAvailabilityZone()).region, usageType, offer.getFixedPrice(), hourly) || hasNewPrice;
```
Specifically it is `Zone.getZone(offer.getAvailabilityZone()).region`
Where `Zone.getZone()` can return null as seen here: https://github.com/netflix/ice/blob/master/src/java/com/netflix/ice/tag/Zone.java#L118
```java
if (name.isEmpty() || name.equals(region.name))
            return null;
```

And after adding some logging I found there was a new zone for `sa-east-1`:
```log
2015-02-26 13:23:13,591 [localhost-startStop-1] WARN  basic.BasicReservationService  - Not able to setting RI price for: zone=sa-east-1c - utilization=HEAVY - usageType=m3.xlarge.sqlserverweb - fixedPrice=10550.0 - hourly=0.0
2015-02-26 13:23:13,591 [localhost-startStop-1] WARN  basic.BasicReservationService  - Not able to setting RI price for: zone=sa-east-1c - utilization=HEAVY - usageType=m3.xlarge.sqlserverstd - fixedPrice=19683.0 - hourly=0.0
```