### PR TITLE
Fix NullPointer when billing data not up to date

### DIFF
--- a/grails-app/controllers/com/netflix/ice/DashboardController.groovy
+++ b/grails-app/controllers/com/netflix/ice/DashboardController.groovy
@@ -428,7 +428,10 @@ class DashboardController {
             start = dateFormatter.parseDateTime(query.getString("start"));
 
         Interval interval = new Interval(start, end);
-        interval = tagGroupManager.getOverlapInterval(interval);
+        Interval overlap_interval = tagGroupManager.getOverlapInterval(interval);
+        if (overlap_interval != null) {
+            interval = overlap_interval
+        }
         if (interval.getEnd().getMonthOfYear() == new DateTime(DateTimeZone.UTC).getMonthOfYear()) {
             DateTime curMonth = new DateTime(DateTimeZone.UTC).withDayOfMonth(1).withMillisOfDay(0);
             int hoursWithData = getManagers().getUsageManager(null, ConsolidateType.hourly).getDataLength(curMonth);


### PR DESCRIPTION
This null pointer is hit If billing data hasn't been processed lately(which is what happens in my staging/test environments)