### PR TITLE
Added Docker image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ Using basic setup, you don't need any extra code change and you will use the pro
 
 1. A community cookbook is available for deploying Ice via Chef here https://github.com/mdsol/ice_cookbook.
 
+##Ice Docker Image:
+
+1. A community image is available for deploying Ice via Docker here https://github.com/jonbrouse/docker-ice
+
   
 ##Advanced options:
 Options with * require writing your own code.


### PR DESCRIPTION
In an effort to simplify the deployment of the project I created a Dockerfile for Ice and a Nginx proxy. It uses Docker Compose to pull down both images and links them together. I wanted to share and see if you were interested in verify the legitimacy of the build and possibly adding it to your docs. It uses a Java container that I also maintain: https://registry.hub.docker.com/u/jonbrouse/java/

Thanks,
Jon

Oh and thank you for writing this, you guys rock.