### PR TITLE
avoid NullPointerException for invalid AZ

### DIFF
--- a/src/java/com/netflix/ice/basic/BasicReservationService.java
+++ b/src/java/com/netflix/ice/basic/BasicReservationService.java
@@ -172,8 +172,10 @@ public class BasicReservationService extends Poller implements ReservationServic
                     }
                     UsageType usageType = getUsageType(offer.getInstanceType(), offer.getProductDescription());
                     // Unknown Zone
-                    if (Zone.getZone(offer.getAvailabilityZone()) == null) 
+                    if (Zone.getZone(offer.getAvailabilityZone()) == null){ 
                         logger.error("No Zone for " + offer.getAvailabilityZone());
+                        continue;
+                    }
                     hasNewPrice = setPrice(utilization, currentTime, Zone.getZone(offer.getAvailabilityZone()).region, usageType,
                             offer.getFixedPrice(), hourly) || hasNewPrice;
 


### PR DESCRIPTION
I failed to run the original code in processor mode, because it tried to load EC2 RI pricing for ap-southeast-2c. Odd enough, it's not defined in com.netflix.ice.tag.Zone

But obviously, there is a coding issue than you should quit the current loop if the zone doesn't exist, not just logger.error and let NPE occurs in next statement.

Please review.