### PR TITLE
Change auth mechanism to support the standards.

### DIFF
--- a/grails-app/conf/BootStrap.groovy
+++ b/grails-app/conf/BootStrap.groovy
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory
 import com.netflix.ice.common.IceOptions
 import com.netflix.ice.processor.ReservationCapacityPoller
 import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.auth.InstanceProfileCredentialsProvider
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.netflix.ice.basic.BasicAccountService
 import com.google.common.collect.Lists
 import com.netflix.ice.tag.Account
@@ -75,7 +75,7 @@ class BootStrap {
             AWSCredentialsProvider credentialsProvider;
 
             if (StringUtils.isEmpty(System.getProperty("ice.s3AccessKeyId")) || StringUtils.isEmpty(System.getProperty("ice.s3SecretKey")))
-                credentialsProvider = new InstanceProfileCredentialsProvider();
+                credentialsProvider = new DefaultAWSCredentialsProviderChain();
             else
                 credentialsProvider = new AWSCredentialsProvider() {
                         public AWSCredentials getCredentials() {


### PR DESCRIPTION
This update changes the default auth mechanism to allow the SDK to use
whatever crdentials are available if the key and token aren't provided
in the config. This will allow ice to work in additional environments
such as Amazon ECS, while still allowing the original enviornments to
continue working as they had.

Assuming the credentials aren't provided in the config, they will be
found and used in the following order (direct cut/paste from the Java SDK
documentation):

---

AWS credentials provider chain that looks for credentials in this order:
 - Environment Variables - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY (RECOMMENDED since they are recognized by all the AWS SDKs and CLI except for .NET), or AWS_ACCESS_KEY and AWS_SECRET_KEY (only recognized by Java SDK)
 - Java System Properties - aws.accessKeyId and aws.secretKey
 - Credential profiles file at the default location (~/.aws/credentials) shared by all AWS SDKs and the AWS CLI
 - Credentials delivered through the Amazon EC2 container service if AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" environment variable is set and security manager has permission to access the variable,
 - Instance profile credentials delivered through the Amazon EC2 metadata service