### PR TITLE
Update AWS Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /*.tmproj
 /ivy*
 /eclipse
+/.idea/*
 
 # default HSQL database files for production mode
 /prodDb.*

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -66,12 +66,12 @@ grails.project.dependency.resolution = {
 
         compile(
                 // Amazon Web Services programmatic interface
-                'com.amazonaws:aws-java-sdk:1.11.136',
+                'com.amazonaws:aws-java-sdk:1.11.221',
                 // Transitive dependencies of aws-java-sdk, but also used directly.
                 // It would be great if we could upgrade httpcore and httpclient, but we can't until the AWS Java SDK
                 // upgrades its dependencies. If we simply upgrade these, then some Amazon calls fail.
-                'org.apache.httpcomponents:httpcore:4.4.4',
-                'org.apache.httpcomponents:httpclient:4.5.2',
+                'org.apache.httpcomponents:httpcore:4.4.7',
+                'org.apache.httpcomponents:httpclient:4.5.3',
 
                 // Explicitly including aws-java-sdk transitive dependencies
                 'org.codehaus.jackson:jackson-core-asl:1.8.9',

--- a/src/java/com/netflix/ice/basic/BasicManagers.java
+++ b/src/java/com/netflix/ice/basic/BasicManagers.java
@@ -17,13 +17,18 @@
  */
 package com.netflix.ice.basic;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.netflix.ice.common.*;
+import com.netflix.ice.common.AwsUtils;
+import com.netflix.ice.common.ConsolidateType;
+import com.netflix.ice.common.Poller;
 import com.netflix.ice.processor.TagGroupWriter;
-import com.netflix.ice.reader.*;
+import com.netflix.ice.reader.DataManager;
+import com.netflix.ice.reader.Managers;
+import com.netflix.ice.reader.ReaderConfig;
+import com.netflix.ice.reader.TagGroupManager;
 import com.netflix.ice.tag.Product;
 import com.netflix.ice.tag.Tag;
 
@@ -91,7 +96,7 @@ public class BasicManagers extends Poller implements Managers {
         TreeMap<Key, BasicDataManager> usageManagers = Maps.newTreeMap(this.usageManagers);
 
         Set<Product> newProducts = Sets.newHashSet();
-        AmazonS3Client s3Client = AwsUtils.getAmazonS3Client();
+        AmazonS3 s3Client = AwsUtils.getAmazonS3Client();
         for (S3ObjectSummary s3ObjectSummary: s3Client.listObjects(config.workS3BucketName, config.workS3BucketPrefix + TagGroupWriter.DB_PREFIX).getObjectSummaries()) {
             String key = s3ObjectSummary.getKey();
             Product product;

--- a/src/java/com/netflix/ice/basic/BasicS3ApplicationGroupService.java
+++ b/src/java/com/netflix/ice/basic/BasicS3ApplicationGroupService.java
@@ -17,7 +17,7 @@
  */
 package com.netflix.ice.basic;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.google.common.collect.Maps;
 import com.netflix.ice.common.AwsUtils;
@@ -38,7 +38,7 @@ import java.util.Map;
 
 public class BasicS3ApplicationGroupService implements ApplicationGroupService {
     private final static Logger logger = LoggerFactory.getLogger(BasicS3ApplicationGroupService.class);
-    private AmazonS3Client s3Client;
+    private AmazonS3 s3Client;
     private ReaderConfig config;
 
     public void init() {

--- a/src/java/com/netflix/ice/basic/BasicWeeklyCostEmailService.java
+++ b/src/java/com/netflix/ice/basic/BasicWeeklyCostEmailService.java
@@ -17,7 +17,7 @@
  */
 package com.netflix.ice.basic;
 
-import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
 import com.amazonaws.services.simpleemail.model.RawMessage;
 import com.amazonaws.services.simpleemail.model.SendRawEmailRequest;
 import com.google.common.collect.Lists;
@@ -67,7 +67,10 @@ import java.nio.ByteBuffer;
 import java.text.FieldPosition;
 import java.text.NumberFormat;
 import java.text.ParsePosition;
-import java.util.*;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
 
 public class BasicWeeklyCostEmailService extends Poller {
 
@@ -176,7 +179,7 @@ public class BasicWeeklyCostEmailService extends Poller {
         try {
             headerNote = getHeaderNote();
             throughputMetrics = getThroughputMetrics();
-            AmazonSimpleEmailServiceClient emailService = AwsUtils.getAmazonSimpleEmailServiceClient();
+            AmazonSimpleEmailService emailService = AwsUtils.getAmazonSimpleEmailServiceClient();
             Map<String, ApplicationGroup> appgroups = applicationGroupService.getApplicationGroups();
             Map<String, List<ApplicationGroup>> appgroupsByEmail = collectEmails(appgroups);
 
@@ -440,7 +443,7 @@ public class BasicWeeklyCostEmailService extends Poller {
         return mimeBodyPart;
     }
 
-    private void sendEmail(boolean test, AmazonSimpleEmailServiceClient emailService, String email, List<ApplicationGroup> appGroups)
+    private void sendEmail(boolean test, AmazonSimpleEmailService emailService, String email, List<ApplicationGroup> appGroups)
         throws IOException, MessagingException {
 
         StringBuilder body = new StringBuilder();

--- a/src/java/com/netflix/ice/basic/MapDb.java
+++ b/src/java/com/netflix/ice/basic/MapDb.java
@@ -17,7 +17,7 @@
  */
 package com.netflix.ice.basic;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.netflix.ice.common.AwsUtils;
 import com.netflix.ice.processor.ProcessorConfig;
@@ -47,7 +47,7 @@ public class MapDb {
         this.dbName = "db_" + name;
         File file = new File(config.localDir, dbName);
         if (!file.exists()) {
-            AmazonS3Client s3Client = AwsUtils.getAmazonS3Client();
+            AmazonS3 s3Client = AwsUtils.getAmazonS3Client();
             for (S3ObjectSummary s3ObjectSummary: s3Client.listObjects(config.workS3BucketName, config.workS3BucketPrefix + this.dbName).getObjectSummaries()) {
                 File dbFile = new File(config.localDir, s3ObjectSummary.getKey().substring(config.workS3BucketPrefix.length()));
                 AwsUtils.downloadFileIfNotExist(config.workS3BucketName, config.workS3BucketPrefix, dbFile);
@@ -103,7 +103,7 @@ public class MapDb {
     }
 
     void upload() {
-        AmazonS3Client s3Client = AwsUtils.getAmazonS3Client();
+        AmazonS3 s3Client = AwsUtils.getAmazonS3Client();
 
         File dir = new File(config.localDir);
         File[] files = dir.listFiles(new FilenameFilter() {

--- a/src/java/com/netflix/ice/processor/BillingFileProcessor.java
+++ b/src/java/com/netflix/ice/processor/BillingFileProcessor.java
@@ -17,7 +17,7 @@
  */
 package com.netflix.ice.processor;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
@@ -26,15 +26,16 @@ import com.csvreader.CsvReader;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.netflix.ice.common.*;
+import com.netflix.ice.common.AwsUtils;
+import com.netflix.ice.common.Poller;
+import com.netflix.ice.common.TagGroup;
 import com.netflix.ice.tag.Account;
 import com.netflix.ice.tag.Operation;
 import com.netflix.ice.tag.Product;
-import com.netflix.ice.tag.Zone;
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
-import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Months;
@@ -648,12 +649,12 @@ public class BillingFileProcessor extends Poller {
     }
 
     private void updateLastMillis(long millis, String filename) {
-        AmazonS3Client s3Client = AwsUtils.getAmazonS3Client();
+        AmazonS3 s3Client = AwsUtils.getAmazonS3Client();
         s3Client.putObject(config.workS3BucketName, config.workS3BucketPrefix + filename, IOUtils.toInputStream(millis + ""), new ObjectMetadata());
     }
 
     private Long getLastMillis(String filename) {
-        AmazonS3Client s3Client = AwsUtils.getAmazonS3Client();
+        AmazonS3 s3Client = AwsUtils.getAmazonS3Client();
         InputStream in = null;
         try {
             in = s3Client.getObject(config.workS3BucketName, config.workS3BucketPrefix + filename).getObjectContent();

--- a/src/java/com/netflix/ice/processor/BillingFileProcessor.java
+++ b/src/java/com/netflix/ice/processor/BillingFileProcessor.java
@@ -20,7 +20,7 @@ package com.netflix.ice.processor;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
-import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient;
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
 import com.amazonaws.services.simpleemail.model.*;
 import com.csvreader.CsvReader;
 import com.google.common.collect.Lists;
@@ -729,7 +729,7 @@ public class BillingFileProcessor extends Poller {
             request.withDestination(new Destination(emails));
             request.withMessage(new Message(new Content(subject), new Body().withHtml(new Content(body.toString()))));
 
-            AmazonSimpleEmailServiceClient emailService = AwsUtils.getAmazonSimpleEmailServiceClient();
+            AmazonSimpleEmailService emailService = AwsUtils.getAmazonSimpleEmailServiceClient();
             try {
                 emailService.sendEmail(request);
                 updateLastAlertMillis(endMilli);

--- a/src/java/com/netflix/ice/reader/ReaderConfig.java
+++ b/src/java/com/netflix/ice/reader/ReaderConfig.java
@@ -83,7 +83,7 @@ public class ReaderConfig extends Config {
 
         ReaderConfig.instance = this;
 
-//        AmazonS3Client s3Client = AwsUtils.getAmazonS3Client();
+//        AmazonS3 s3Client = AwsUtils.getAmazonS3Client();
 //        logger.info("Deleting all files...");
 //        List<S3ObjectSummary> objectSummariesToDelete = AwsUtils.listAllObjects(instance.workS3BucketName, instance.workS3BucketPrefix);
 //        for (S3ObjectSummary objectSummary : objectSummariesToDelete) {


### PR DESCRIPTION
This PR updates AWS Java SDK to 1.11.221.

All AWS clients are using builder class to instantiate. 

This fixes some edge cases when calling AWS api to us-east-1 region including API calls to upload file to S3,  download file from S3 and get EC2 reservation pricing.